### PR TITLE
Add Download Links for Alternative Architecture for Agent Installation

### DIFF
--- a/Mac/Agent/install-produce8-agent.sh
+++ b/Mac/Agent/install-produce8-agent.sh
@@ -35,7 +35,6 @@ curl -L "https://desktop-agent-assets-main.s3.us-west-2.amazonaws.com/main/pkg/a
 # For x64 devices use this link instead
 # curl -L "https://desktop-agent-assets-main.s3.us-west-2.amazonaws.com/main/pkg/x64/Produce8-Agent-latest.pkg" -o "$PKG_PATH"
 
-
 if [[ $? -ne 0 ]]; then
   echo "Unable to download the Produce8 agent installer file"
   exit 1

--- a/Mac/Agent/install-produce8-agent.sh
+++ b/Mac/Agent/install-produce8-agent.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# Create the account properties config file 
+# This script will
+#   1. Create the account properties config file
+#   2. Download the installer from AWS S3
+#   3. Run the installer
+
 # Set your account id by replacing # in the next line. ie. accountId=59079b49-772c-453b-bb33-70a04e372466
 accountId=#
 configFileDir="/Users/Shared/Produce8-Agent"
@@ -27,6 +31,10 @@ PKG_PATH="/tmp/Produce8-Agent-latest.pkg"
 
 # Download the pkg
 curl -L "https://desktop-agent-assets-main.s3.us-west-2.amazonaws.com/main/pkg/arm64/Produce8-Agent-latest.pkg" -o "$PKG_PATH"
+
+# For x64 devices use this link instead
+# curl -L "https://desktop-agent-assets-main.s3.us-west-2.amazonaws.com/main/pkg/x64/Produce8-Agent-latest.pkg" -o "$PKG_PATH"
+
 
 if [[ $? -ne 0 ]]; then
   echo "Unable to download the Produce8 agent installer file"

--- a/PC/Agent/Install-Produce8-Agent.ps1
+++ b/PC/Agent/Install-Produce8-Agent.ps1
@@ -1,3 +1,8 @@
+# This script will
+#   1. Create a temporary directory 
+#   2. Download the installer from AWS S3 to the temp directory
+#   3. Run the installer from the temp directory
+
 $tempDir = ""
 
 if (Test-Path -Path 'C:\tmp'){
@@ -6,6 +11,7 @@ if (Test-Path -Path 'C:\tmp'){
 elseif (Test-Path -Path 'C:\temp'){
     $tempDir = "C:\temp"
 } else {
+    # Create the temp folder if it does not exist
     $tempDir = 'C:\tmp'
     New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
 }
@@ -13,6 +19,10 @@ elseif (Test-Path -Path 'C:\temp'){
 $path = $tempDir+'\produce8-agent-latest.msi'
 
 Invoke-WebRequest https://desktop-agent-assets-main.s3.us-west-2.amazonaws.com/main/msi/x64/Produce8-Agent-latest.msi -OutFile $path 
-# Run it with the right accountId 
+
+# For Arm64 devices use this link instead
+#Invoke-WebRequest https://desktop-agent-assets-main.s3.us-west-2.amazonaws.com/main/msi/arm64/Produce8-Agent-latest.msi -OutFile $path 
+
+# Set your account id by replacing # in the next line.
 # ie. Start-Process -Wait msiexec -argumentlist "/i C:\tmp\produce8.msi /quiet ACCOUNTID=59079b49-772c-453b-bb33-70a04e372466"
-Start-Process -Wait msiexec -argumentlist "/i $path /quiet ACCOUNTID=###"
+Start-Process -Wait msiexec -argumentlist "/i $path /quiet ACCOUNTID=#"


### PR DESCRIPTION
- add link to download installer for alternative architecture. Commented out by default so only one link is used when script is run.