### PR TITLE
Change Windows Firefox Scripts to use Policies.json

### DIFF
--- a/PC/Agent/Install-Produce8-Agent.ps1
+++ b/PC/Agent/Install-Produce8-Agent.ps1
@@ -31,7 +31,7 @@ $path = Join-Path $tempDir 'produce8-agent-latest.msi'
 Write-Output "MSI will be saved to: $path"
 
 # Download the MSI
-Write-Output "Downloading Produce8 Desktop App installer..."
+Write-Output "Downloading Produce8 Agent MSI installer..."
 try {
     $downloadUrl = "https://desktop-agent-assets-main.s3.us-west-2.amazonaws.com/main/msi/x64/Produce8-Agent-latest.msi"
     #For ARM64 devices, use this URL instead:
@@ -51,7 +51,7 @@ if (-not (Test-Path $path)) {
 }
 
 # Install the MSI
-Write-Output "Installing Produce8 Desktop App..."
+Write-Output "Installing Produce8 Agent..."
 try {
     # Set your account id by replacing # in the next line. ie. ACCOUNTID=59079b49-772c-453b-bb33-70a04e372466
     # The account id can be found in the Produce8 portal under the "Account Settings" menu.

--- a/PC/BrowserPlugin/Chrome/Install-Chrome-Plugin.ps1
+++ b/PC/BrowserPlugin/Chrome/Install-Chrome-Plugin.ps1
@@ -24,3 +24,4 @@ $regValue = "$extensionID;$updateURL"
 Set-ItemProperty -Path $regPath -Name "1" -Value $regValue -Force
 
 Write-Output "Installation complete. Google Chrome extension policy set."
+Write-Output "Restart Chrome to apply changes."

--- a/PC/BrowserPlugin/Edge/Install-Edge-Plugin.ps1
+++ b/PC/BrowserPlugin/Edge/Install-Edge-Plugin.ps1
@@ -24,3 +24,4 @@ $regValue = "$extensionID;$updateURL"
 Set-ItemProperty -Path $regPath -Name "1" -Value $regValue -Force
 
 Write-Output "Installation complete. Edge extension policy set."
+Write-Output "Restart Edge to apply changes."

--- a/PC/BrowserPlugin/FireFox/Install-Firefox-Plugin.ps1
+++ b/PC/BrowserPlugin/FireFox/Install-Firefox-Plugin.ps1
@@ -64,7 +64,7 @@ if (-not (Test-Path $distributionDir)) {
         New-Item -Path $distributionDir -ItemType Directory -Force | Out-Null
         Write-Output "Created distribution directory: $distributionDir"
     } catch {
-        Write-Output "ERROR: Could not create distribution directory: $_"
+        Write-Output "ERROR: Could not create distribution directory."
         exit 1
     }
 }
@@ -119,7 +119,7 @@ try {
     [System.IO.File]::WriteAllText($policiesFile, $jsonContent, $utf8NoBom)
     Write-Output "Successfully created/updated policies.json at: $policiesFile"
 } catch {
-    Write-Output "ERROR: Could not write policies.json file: $_"
+    Write-Output "ERROR: Could not write policies.json file."
     exit 1
 }
 

--- a/PC/BrowserPlugin/FireFox/Install-Firefox-Plugin.ps1
+++ b/PC/BrowserPlugin/FireFox/Install-Firefox-Plugin.ps1
@@ -1,47 +1,131 @@
-# PowerShell Script to install Firefox Extension Registry Policy 
-# Run this script with administrative privileges in order to modify the registry
+# PowerShell Script to install Firefox Extension via Group Policy (policies.json)
+# Run this script with administrative privileges
 # The browser will require a restart to enable the extension
 
-# Define the extension URL
-Write-Output "Installing P8 extension policy for Mozilla Firefox"
-$extensionURL = "https://addons.mozilla.org/firefox/downloads/latest/produce8-agent/latest.xpi"
-
-# Define the registry path for Firefox Extensions
-$regPath = "HKLM:\SOFTWARE\Policies\Mozilla\Firefox\Extensions\Install"
-
-# Check if registry path exists
-if (-not (Test-Path $regPath)) {
-    # Create the registry path
-    New-Item -Path $regPath -Force | Out-Null
-    Write-Output "Created registry path: $regPath"
-}
-
-# Find next available registry key
-$existingKeys = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | Where-Object { $_ -match '^\d+$' }
-$regValueName = 1
-if ($existingKeys) {
-    $maxKey = ($existingKeys | ForEach-Object { [int]$_ } | Measure-Object -Maximum).Maximum
-    $regValueName = $maxKey + 1
-}
-
-# Check if extension URL already exists
-$existingProps = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue
-$alreadyExists = $false
-if ($existingProps) {
-    $existingProps.PSObject.Properties | Where-Object { $_.Name -notmatch '^PS(.*)' } | ForEach-Object {
-        if ($_.Value -eq $extensionURL) {
-            Write-Output "Extension already registered with key: $($_.Name)"
-            $alreadyExists = $true
+# Helper function to convert PSCustomObject to Hashtable
+function ConvertTo-Hashtable {
+    param([Parameter(ValueFromPipeline)]$InputObject)
+    process {
+        if ($null -eq $InputObject) { return $null }
+        if ($InputObject -is [Hashtable]) { return $InputObject }
+        if ($InputObject -is [PSCustomObject]) {
+            $hash = @{}
+            $InputObject.PSObject.Properties | ForEach-Object {
+                $value = $_.Value
+                if ($value -is [PSCustomObject]) {
+                    $hash[$_.Name] = ConvertTo-Hashtable $value
+                } elseif ($value -is [Array]) {
+                    $hash[$_.Name] = $value | ForEach-Object { ConvertTo-Hashtable $_ }
+                } else {
+                    $hash[$_.Name] = $value
+                }
+            }
+            return $hash
         }
+        return $InputObject
     }
 }
 
-# Add the registry entry if it doesn't already exist
-if (-not $alreadyExists) {
-    Set-ItemProperty -Path $regPath -Name $regValueName -Value $extensionURL -Force
-    Write-Output "Registered extension with key: $regValueName"
-    Write-Output "Extension URL: $extensionURL"
+Write-Output "Installing P8 extension policy for Mozilla Firefox"
+
+# Extension configuration
+$extensionId = "support@produce8.com"
+$installUrl = "https://addons.mozilla.org/firefox/downloads/file/4579169/produce8_agent-3.1.37.xpi"
+
+# Find Firefox installation directory
+$firefoxPaths = @(
+    "${env:ProgramFiles}\Mozilla Firefox",
+    "${env:ProgramFiles(x86)}\Mozilla Firefox"
+)
+
+$firefoxPath = $null
+foreach ($path in $firefoxPaths) {
+    if (Test-Path $path) {
+        $firefoxPath = $path
+        break
+    }
 }
 
+if (-not $firefoxPath) {
+    Write-Output "ERROR: Could not find Firefox installation directory"
+    Write-Output "Searched in: $($firefoxPaths -join ', ')"
+    exit 1
+}
+
+Write-Output "Found Firefox installation: $firefoxPath"
+
+# Define policies.json location
+$distributionDir = Join-Path $firefoxPath "distribution"
+$policiesFile = Join-Path $distributionDir "policies.json"
+
+# Create distribution directory if it doesn't exist
+if (-not (Test-Path $distributionDir)) {
+    try {
+        New-Item -Path $distributionDir -ItemType Directory -Force | Out-Null
+        Write-Output "Created distribution directory: $distributionDir"
+    } catch {
+        Write-Output "ERROR: Could not create distribution directory: $_"
+        exit 1
+    }
+}
+
+# Read existing policies.json if it exists
+$policies = @{}
+if (Test-Path $policiesFile) {
+    try {
+        $existingContent = Get-Content $policiesFile -Raw -ErrorAction Stop
+        $policies = $existingContent | ConvertFrom-Json -ErrorAction Stop | ConvertTo-Hashtable
+        Write-Output "Found existing policies.json, preserving existing policies..."
+    } catch {
+        Write-Output "WARNING: Could not parse existing policies.json, will create new one"
+        Write-Output "Error: $_"
+        $policies = @{}
+    }
+}
+
+# Ensure policies structure exists
+if (-not $policies.ContainsKey("policies")) {
+    $policies["policies"] = @{}
+}
+
+# Convert to hashtable if it's a PSCustomObject
+if ($policies["policies"] -is [PSCustomObject]) {
+    $policies["policies"] = $policies["policies"] | ConvertTo-Hashtable
+}
+
+# Ensure ExtensionSettings exists
+if (-not $policies["policies"].ContainsKey("ExtensionSettings")) {
+    $policies["policies"]["ExtensionSettings"] = @{}
+}
+
+# Convert ExtensionSettings to hashtable if needed
+if ($policies["policies"]["ExtensionSettings"] -is [PSCustomObject]) {
+    $policies["policies"]["ExtensionSettings"] = $policies["policies"]["ExtensionSettings"] | ConvertTo-Hashtable
+}
+
+# Add or update our extension
+$policies["policies"]["ExtensionSettings"][$extensionId] = @{
+    installation_mode = "force_installed"
+    install_url = $installUrl
+}
+
+# Convert back to JSON with proper formatting
+$jsonContent = $policies | ConvertTo-Json -Depth 10
+
+# Write policies.json file with UTF-8 encoding without BOM (Firefox requirement)
+try {
+    # Use UTF8NoBOM encoding
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllText($policiesFile, $jsonContent, $utf8NoBom)
+    Write-Output "Successfully created/updated policies.json at: $policiesFile"
+} catch {
+    Write-Output "ERROR: Could not write policies.json file: $_"
+    exit 1
+}
+
+Write-Output ""
+Write-Output "Policy file contents:"
+Write-Output $jsonContent
+Write-Output ""
 Write-Output "Installation complete. Mozilla Firefox extension policy set."
 Write-Output "Restart Firefox to apply changes."

--- a/PC/BrowserPlugin/FireFox/Install-Firefox-Plugin.ps1
+++ b/PC/BrowserPlugin/FireFox/Install-Firefox-Plugin.ps1
@@ -1,48 +1,47 @@
 # PowerShell Script to install Firefox Extension Registry Policy 
 # Run this script with administrative privileges in order to modify the registry
-# The broswer will require a restart to enable the extension
+# The browser will require a restart to enable the extension
 
-$extensionURL   = "https://addons.mozilla.org/firefox/downloads/latest/produce8-agent/latest.xpi"
-$localTempDir   = Join-Path $env:TEMP "FirefoxExtension"
-$localXpiPath   = Join-Path $localTempDir "produce8-agent.xpi"
-$regPath        = "HKLM:\SOFTWARE\Policies\Mozilla\Firefox\Extensions\Install"
+# Define the extension URL
+Write-Output "Installing P8 extension policy for Mozilla Firefox"
+$extensionURL = "https://addons.mozilla.org/firefox/downloads/latest/produce8-agent/latest.xpi"
 
-Write-Output "Instaling P8 extension policy for Mozilla Firefox"
+# Define the registry path for Firefox Extensions
+$regPath = "HKLM:\SOFTWARE\Policies\Mozilla\Firefox\Extensions\Install"
 
-# Create local folder
-if (-not (Test-Path $localTempDir)) { 
-    New-Item -Path $localTempDir -ItemType Directory | Out-Null
-    Write-Output "Created local folder: $localTempDir"
-} else {
-    Write-Output "Local folder already exists: $localTempDir"
-}
-
-# Download the extension
-try {
-    Write-Output "Downloading extension from $extensionURL..."
-    Invoke-WebRequest -Uri $extensionURL -OutFile $localXpiPath -UseBasicParsing
-    Write-Output "Extension downloaded to $localXpiPath"
-} catch {
-    Write-Output "ERROR: Failed to download extension. $_"
-    throw
-}
-
-# Ensure registry path exists
+# Check if registry path exists
 if (-not (Test-Path $regPath)) {
+    # Create the registry path
     New-Item -Path $regPath -Force | Out-Null
     Write-Output "Created registry path: $regPath"
-} else {
-    Write-Output "Registry path already exists: $regPath"
 }
 
 # Find next available registry key
-$existingKeys = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+$existingKeys = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name | Where-Object { $_ -match '^\d+$' }
 $regValueName = 1
-while ($existingKeys -contains $regValueName.ToString()) { $regValueName++ }
-Write-Output "Using registry key: $regValueName"
+if ($existingKeys) {
+    $maxKey = ($existingKeys | ForEach-Object { [int]$_ } | Measure-Object -Maximum).Maximum
+    $regValueName = $maxKey + 1
+}
 
-# Add registry entry
-Set-ItemProperty -Path $regPath -Name $regValueName -Value $localXpiPath -Force
-Write-Output "Registry updated to install extension."
+# Check if extension URL already exists
+$existingProps = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue
+$alreadyExists = $false
+if ($existingProps) {
+    $existingProps.PSObject.Properties | Where-Object { $_.Name -notmatch '^PS(.*)' } | ForEach-Object {
+        if ($_.Value -eq $extensionURL) {
+            Write-Output "Extension already registered with key: $($_.Name)"
+            $alreadyExists = $true
+        }
+    }
+}
 
-Write-Output "Installation complete. Verify in Firefox: about:policies -> Active Policies."
+# Add the registry entry if it doesn't already exist
+if (-not $alreadyExists) {
+    Set-ItemProperty -Path $regPath -Name $regValueName -Value $extensionURL -Force
+    Write-Output "Registered extension with key: $regValueName"
+    Write-Output "Extension URL: $extensionURL"
+}
+
+Write-Output "Installation complete. Mozilla Firefox extension policy set."
+Write-Output "Restart Firefox to apply changes."

--- a/PC/BrowserPlugin/FireFox/Uninstall-Firefox-Plugin.ps1
+++ b/PC/BrowserPlugin/FireFox/Uninstall-Firefox-Plugin.ps1
@@ -1,14 +1,13 @@
 # PowerShell Script to Remove Firefox Extension Registry Policy
-# Run this script with administrative privileges in order to modify the registry
-# The broswer will require a restart for changes to take affect
+# Run this script with administrative privileges
+# The browser will require a restart for changes to take effect
 
-Write-Output "Uninstalling P8 extension policy for Firefox"
+Write-Output "Uninstalling P8 extension policy for Mozilla Firefox"
 
-# The registry path where the policy is set
+# Registry path for Firefox Extensions
 $regPath = "HKLM:\SOFTWARE\Policies\Mozilla\Firefox\Extensions\Install"
 $extensionURL = "https://addons.mozilla.org/firefox/downloads/latest/produce8-agent/latest.xpi"
 
-# Get all name value pairs at the install path
 if (Test-Path $regPath) {
     $props = Get-ItemProperty -Path $regPath
     $removed = $false
@@ -26,7 +25,7 @@ if (Test-Path $regPath) {
         }
     }
 
-    # Check if the registry key is empty and remove it if so
+    # Clean up if the key is empty
     if ($removed) {
         $remaining = (Get-ItemProperty -Path $regPath).PSObject.Properties |
                      Where-Object { $_.Name -notmatch '^PS(.*)' }
@@ -42,7 +41,7 @@ if (Test-Path $regPath) {
         }
     }
     else {
-        Write-Output "No matching extension policy found for Produce8 agent."
+        Write-Output "No matching Firefox extension policy found for Produce8 agent."
         exit
     }
 } else {
@@ -50,4 +49,4 @@ if (Test-Path $regPath) {
     exit
 }
 
-Write-Output "Firefox extension policy uninstalled successfully. Restart Firefox to apply changes."
+Write-Output "Mozilla Firefox extension policy uninstalled successfully. Restart Firefox to apply changes."

--- a/PC/BrowserPlugin/FireFox/Uninstall-Firefox-Plugin.ps1
+++ b/PC/BrowserPlugin/FireFox/Uninstall-Firefox-Plugin.ps1
@@ -1,52 +1,176 @@
-# PowerShell Script to Remove Firefox Extension Registry Policy
+# PowerShell Script to Remove Firefox Extension via Group Policy (policies.json)
 # Run this script with administrative privileges
 # The browser will require a restart for changes to take effect
 
-Write-Output "Uninstalling P8 extension policy for Mozilla Firefox"
-
-# Registry path for Firefox Extensions
-$regPath = "HKLM:\SOFTWARE\Policies\Mozilla\Firefox\Extensions\Install"
-$extensionURL = "https://addons.mozilla.org/firefox/downloads/latest/produce8-agent/latest.xpi"
-
-if (Test-Path $regPath) {
-    $props = Get-ItemProperty -Path $regPath
-    $removed = $false
-
-    foreach ($prop in $props.PSObject.Properties) {
-        if ($prop.Value -eq $extensionURL) {
-            try {
-                Remove-ItemProperty -Path $regPath -Name $prop.Name -ErrorAction Stop
-                Write-Output "Removed registry entry: $regPath\$($prop.Name)"
-                $removed = $true
+# Helper function to convert PSCustomObject to Hashtable
+function ConvertTo-Hashtable {
+    param([Parameter(ValueFromPipeline)]$InputObject)
+    process {
+        if ($null -eq $InputObject) { return $null }
+        if ($InputObject -is [Hashtable]) { return $InputObject }
+        if ($InputObject -is [PSCustomObject]) {
+            $hash = @{}
+            $InputObject.PSObject.Properties | ForEach-Object {
+                $value = $_.Value
+                if ($value -is [PSCustomObject]) {
+                    $hash[$_.Name] = ConvertTo-Hashtable $value
+                } elseif ($value -is [Array]) {
+                    $hash[$_.Name] = $value | ForEach-Object { ConvertTo-Hashtable $_ }
+                } else {
+                    $hash[$_.Name] = $value
+                }
             }
-            catch {
-                Write-Output "Failed to remove $($prop.Name): $_"
-            }
+            return $hash
         }
+        return $InputObject
     }
-
-    # Clean up if the key is empty
-    if ($removed) {
-        $remaining = (Get-ItemProperty -Path $regPath).PSObject.Properties |
-                     Where-Object { $_.Name -notmatch '^PS(.*)' }
-
-        if (-not $remaining) {
-            try {
-                Remove-Item -Path $regPath -Recurse -Force
-                Write-Output "Registry path $regPath was empty and has been removed."
-            }
-            catch {
-                Write-Output "Failed to remove empty registry path: $_"
-            }
-        }
-    }
-    else {
-        Write-Output "No matching Firefox extension policy found for Produce8 agent."
-        exit
-    }
-} else {
-    Write-Output "No Firefox extension policy registry path found."
-    exit
 }
 
-Write-Output "Mozilla Firefox extension policy uninstalled successfully. Restart Firefox to apply changes."
+Write-Output "Uninstalling P8 extension policy for Mozilla Firefox"
+
+# Extension ID (must match install script)
+$extensionId = "support@produce8.com"
+
+# Remove extension policy from policies.json
+Write-Output "Removing extension from policies.json"
+
+$firefoxPaths = @(
+    "${env:ProgramFiles}\Mozilla Firefox",
+    "${env:ProgramFiles(x86)}\Mozilla Firefox"
+)
+
+$firefoxPath = $null
+foreach ($path in $firefoxPaths) {
+    if (Test-Path $path) {
+        $firefoxPath = $path
+        break
+    }
+}
+
+if ($firefoxPath) {
+    $policiesFile = Join-Path $firefoxPath "distribution\policies.json"
+    
+    if (Test-Path $policiesFile) {
+        try {
+            $existingContent = Get-Content $policiesFile -Raw -ErrorAction Stop
+            $policies = $existingContent | ConvertFrom-Json -ErrorAction Stop | ConvertTo-Hashtable
+            
+            # Check if our extension exists in ExtensionSettings
+            if ($policies.policies -and $policies.policies.ExtensionSettings -and $policies.policies.ExtensionSettings.ContainsKey($extensionId)) {
+                $policies.policies.ExtensionSettings.Remove($extensionId)
+                Write-Output "Removed extension from ExtensionSettings"
+                
+                # Clean up empty sections
+                if ($policies.policies.ExtensionSettings.Count -eq 0) {
+                    $policies.policies.Remove("ExtensionSettings")
+                }
+                if ($policies.policies.Count -eq 0) {
+                    $policies.Remove("policies")
+                }
+                
+                # Delete file if empty, otherwise update it
+                if ($policies.Count -eq 0) {
+                    Remove-Item $policiesFile -Force -ErrorAction Stop
+                    Write-Output "Removed policies.json (file was empty)"
+                } else {
+                    $jsonContent = $policies | ConvertTo-Json -Depth 10
+                    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+                    [System.IO.File]::WriteAllText($policiesFile, $jsonContent, $utf8NoBom)
+                    Write-Output "Updated policies.json (removed extension)"
+                }
+            } else {
+                Write-Output "Extension not found in policies.json"
+            }
+        } catch {
+            Write-Output "WARNING: Could not update policies.json: $_"
+        }
+    } else {
+        Write-Output "policies.json not found (may already be removed)"
+    }
+} else {
+    Write-Output "Firefox installation directory not found"
+}
+
+# Remove extension XPI file from all user profiles
+Write-Output ""
+Write-Output "Removing extension XPI files from user profiles..."
+
+# Check all user profiles on the system (not just current user)
+$usersPath = "C:\Users"
+$allProfilesFound = 0
+
+if (Test-Path $usersPath) {
+    $users = Get-ChildItem -Path $usersPath -Directory -ErrorAction SilentlyContinue
+    foreach ($user in $users) {
+        # Skip default system accounts
+        if ($user.Name -match '^(Default|Public|All Users)$') {
+            continue
+        }
+        
+        $userAppData = Join-Path $user.FullName "AppData\Roaming\Mozilla\Firefox\Profiles"
+        Write-Output "User app data: $userAppData"
+        
+        if (Test-Path $userAppData) {
+            Write-Output "Checking user: $($user.Name)"
+            Write-Output "  Profile path: $userAppData"
+            
+            $profiles = Get-ChildItem -Path $userAppData -Directory -ErrorAction SilentlyContinue
+            
+            Write-Output "Profiles: $profiles"
+            
+            if ($null -ne $profiles -and $profiles.Count -gt 0) {
+                Write-Output "  Found $($profiles.Count) profile(s)"
+                
+                foreach ($profile in $profiles) {
+                    $extensionsDir = Join-Path $profile.FullName "extensions"
+                    $extensionXpi = Join-Path $extensionsDir "$extensionId.xpi"
+                    $renamedXpi = Join-Path $extensionsDir "$extensionId.xpi.removed"
+                    
+                    # First, try to clean up any previously renamed files (in case Firefox is now closed)
+                    if (Test-Path $renamedXpi) {
+                        try {
+                            Remove-Item $renamedXpi -Force -ErrorAction Stop
+                            Write-Output "Cleaned up previously renamed file: $renamedXpi"
+                            $allProfilesFound++
+                        } catch {
+                            Write-Output "WARNING: Could not clean up previously renamed file."
+                            # File still locked, skip it
+                        }
+                    }
+                    
+                    # Now try to remove the current XPI file
+                    if (Test-Path $extensionXpi) {
+                        try {
+                            # Try to delete the file first
+                            Remove-Item $extensionXpi -Force -ErrorAction Stop
+                            Write-Output "Removed: $extensionXpi"
+                            $allProfilesFound++
+                        } catch {
+                            # If deletion fails (likely because Firefox is running), rename it instead
+                            # Firefox won't find it with a different name, so the extension won't load
+                            try {
+                                Rename-Item -Path $extensionXpi -NewName "$extensionId.xpi.removed" -Force -ErrorAction Stop
+                                Write-Output "Renamed (Firefox was running): $extensionXpi -> $renamedXpi"
+                                Write-Output "Extension will not load. File will be deleted when Firefox is closed and script is run again"
+                                $allProfilesFound++
+                            } catch {
+                                Write-Output "WARNING: Could not delete or rename $extensionXpi - $_"
+                                Write-Output "Please close Firefox completely and run this script again"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    if ($allProfilesFound -eq 0) {
+        Write-Output "No extension files found in any user profiles"
+    }
+} else {
+    Write-Output "Users directory not found: $usersPath"
+}
+
+Write-Output ""
+Write-Output "Uninstall complete. Please completely close Firefox and restart it to apply changes."
+


### PR DESCRIPTION
FF wasn't being installed consistently when installing via registry keys and best practice for Firefox is using a policies.json file. With help from Cursor the install script now checks for an existing profiles.json file and adds our extension or creates the file if it doesnt exist. 

Uninstall is a bit more complicated - the script removes the extension from profiles.json but the install file (.xpi) remains in user profiles so even though Firefox doesn't detect that a managed policy exists, the extension remains installed. This file can't be deleted if the browser is running so the script will rename it so that Firefox doesn't detect our extension and delete it later. Seems to work consistently.